### PR TITLE
Fix build and update GitHub Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -24,6 +24,6 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: target/*.jar

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -9,7 +9,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -20,7 +20,7 @@
               <relocations>
                 <relocation>
                   <pattern>com.zaxxer.hikari</pattern>
-                  <shadedPattern>de.warsteiner.jobs.libs</shadedPattern>
+                  <shadedPattern>de.warsteiner.jobs.lib</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.3.1-SNAPSHOT</version>
+				<version>3.3.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>


### PR DESCRIPTION
The newest version of maven-shade-plugin on Maven-Central is 3.3.0 not 3.3.1, see: https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-shade-plugin